### PR TITLE
Fix file picker opening horizontally

### DIFF
--- a/lua/unified/file_tree/init.lua
+++ b/lua/unified/file_tree/init.lua
@@ -71,6 +71,7 @@ function M.create_file_tree_buffer(buffer_path, diff_only, commit_ref_arg)
 
   local tree = FileTree.new(root_dir)
 
+  create_split()
   local buf = vim.api.nvim_create_buf(false, true)
 
   local buffer_name = "Unified: File Tree"
@@ -126,6 +127,14 @@ function M.create_file_tree_buffer(buffer_path, diff_only, commit_ref_arg)
   end)
 
   return buf
+end
+
+create_split = function()
+  -- Create new window for tree
+  local config = require("unified.config")
+  local width = config.values.file_tree.width or 30
+  vim.cmd("vsplit")
+  vim.cmd("wincmd p")
 end
 
 -- Removed: auto_select_and_open_first_file (auto-open behavior)
@@ -206,10 +215,6 @@ function M.show(commit_hash)
     return false
   end -- Exit if buffer creation failed
 
-  -- Create new window for tree
-  local config = require("unified.config")
-  local width = config.values.file_tree.width or 30
-  vim.cmd("topleft " .. width .. "vsplit")
   local tree_win = vim.api.nvim_get_current_win()
   vim.api.nvim_win_set_buf(tree_win, tree_buf)
 


### PR DESCRIPTION
Hi,

I was having the issue that the file picker was opening horizontally. I am sure this is probably not the canonical way to fix this issue, but maybe it gives you some idea of what my issue is.

I also am posting the output of winlayout before and after creating the new vsplit for debugging purposes:
```
Before opening tree: { "leaf", 1000 }
After opening tree: { "col", { { "leaf", 1015 }, { "leaf", 1000 } } }
```