### PR TITLE
test: wire test_commit_tree into runner; fix unused vars in render

### DIFF
--- a/lua/unified/file_tree/actions.lua
+++ b/lua/unified/file_tree/actions.lua
@@ -303,7 +303,7 @@ function M.move_cursor_file_only(direction, count)
   local current_line = vim.api.nvim_win_get_cursor(0)[1] - 1 -- 0-based
   for _ = 1, count do
     local next_line = current_line
-    for _i = 1, total_lines do
+    for _ = 1, total_lines do
       next_line = (next_line + direction + total_lines) % total_lines
       local node = tree_state.line_to_node[next_line]
       if node and not node.is_dir then

--- a/lua/unified/file_tree/render.lua
+++ b/lua/unified/file_tree/render.lua
@@ -17,10 +17,6 @@ local function get_shortened_display_parts(full_path)
   elseif #parts == 1 then
     return { "", parts[1] } -- File in root
   else
-    local shortened_parts = {}
-    for i = 1, #parts - 1 do
-      table.insert(shortened_parts, string.sub(parts[i], 1, 1))
-    end
     -- Shorten all parts except the last directory part
     local display_parts = {}
     for i = 1, #parts - 2 do -- Shorten initial parts
@@ -115,7 +111,6 @@ function M.render_tree(tree, buffer)
     local parts = get_shortened_display_parts(relative_path)
     local shortened_path = parts[1]
     local filename = parts[2]
-    local filename = parts[2]
 
     if not grouped_files[shortened_path] then
       grouped_files[shortened_path] = {}
@@ -128,7 +123,7 @@ function M.render_tree(tree, buffer)
   table.sort(group_keys)
 
   -- Sort files within each group alphabetically by filename
-  for key, files_in_group in pairs(grouped_files) do
+  for _, files_in_group in pairs(grouped_files) do
     table.sort(files_in_group, function(a, b)
       return a.name < b.name
     end)
@@ -140,7 +135,7 @@ function M.render_tree(tree, buffer)
   local status_line = ""
   if has_git_dir then
     local changed_count = 0
-    for _, file_node in ipairs(collect_and_filter_files(tree.root, true)) do -- Count all changed files
+    for _, _ in ipairs(collect_and_filter_files(tree.root, true)) do -- Count all changed files
       changed_count = changed_count + 1
     end
 
@@ -167,7 +162,7 @@ function M.render_tree(tree, buffer)
   local extmarks = {}
   local current_line = #lines - 1 -- 0-based index for buffer lines
 
-  for group_idx, shortened_path in ipairs(group_keys) do
+  for _, shortened_path in ipairs(group_keys) do
     local files_in_group = grouped_files[shortened_path]
     local is_root_group = (shortened_path == "")
 
@@ -185,7 +180,7 @@ function M.render_tree(tree, buffer)
     end
 
     -- Render Files in Group
-    for file_idx, file_info in ipairs(files_in_group) do
+    for _, file_info in ipairs(files_in_group) do
       current_line = current_line + 1
       local node = file_info.node
       local indent = is_root_group and "" or "  " -- Indent files under path headers

--- a/test/test_filetree/test_commit_tree.lua
+++ b/test/test_filetree/test_commit_tree.lua
@@ -50,7 +50,7 @@ local function test_commit_file_tree()
     vim.api.nvim_win_close(state.file_tree_win, true)
   end
 
-  state.reset_file_tree_state()
+  require("unified.file_tree.state").reset_state()
 
   print("All file tree commit tests passed!")
   return true

--- a/test/test_runner.lua
+++ b/test/test_runner.lua
@@ -13,6 +13,7 @@ local test_hunk_actions = require("test.test_hunk_actions")
 local test_options = require("test.test_options")
 local test_commit_picker = require("test.test_commit_picker")
 local test_command = require("test.test_command")
+local test_commit_tree = require("test.test_filetree.test_commit_tree")
 -- Helper to run a group of tests
 local function run_test_group(group, group_name)
   local function is_test_function(name)
@@ -79,6 +80,7 @@ function M.run_all_tests()
     { name = "test_options", module = test_options },
     { name = "test_commit_picker", module = test_commit_picker },
     { name = "test_command", module = test_command },
+    { name = "test_commit_tree", module = test_commit_tree },
   }
 
   local all_results = {}
@@ -181,6 +183,7 @@ function M.run_test(test_name)
     test_options = test_options,
     test_commit_picker = test_commit_picker,
     test_command = test_command,
+    test_commit_tree = test_commit_tree,
   }
 
   local group = groups[group_name]


### PR DESCRIPTION
- state.reset_file_tree_state() → require("unified.file_tree.state").reset_state()
- remove duplicate `local filename` declaration in render.lua
- replace unused loop vars (_i, key, group_idx, file_idx) with _
- drop dead shortened_parts block in get_shortened_display_parts
- replace `for _, file_node` with `for _, _` in changed-file counter
- fixes #28